### PR TITLE
Update of package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install ChartJS-PHP via composer
             "url": "https://github.com/Ejdamm/Chart.js-PHP"
         }],
     "require": {
-        "Ejdamm/Chart.js-PHP": "dev-master"
+        "ejdamm/chart.js-php": "dev-master"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ejdamm/Chart.js-PHP",
+  "name": "ejdamm/chart.js-php",
   "homepage": "https://github.com/Ejdamm/Chart.js-PHP",
   "license": "MIT",
   "description": "PHP Wrapper for Chart.js.",


### PR DESCRIPTION
In order to publish the package on packagist.org it's required for the package name to match conventions, which means lower case only.

I think it would be much easier to get started having the package available via packagist.
Especially since @Ejdamm created tagged releases.